### PR TITLE
Add Cloudinary-backed README media workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Strapi IconHub
 
-![Strapi IconHub](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/og-image.jpg)
+![Strapi IconHub](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598287/github/strapi-plugin-iconhub/assets/docs/og-image.jpg)
 
 IconHub is a custom field for Strapi that brings the Iconify catalog into the admin panel. Editors can browse icon sets, search globally, inspect a single set in detail, apply colors, and store either the Iconify name, raw SVG, or both.
 
@@ -29,7 +29,7 @@ IconHub is a custom field for Strapi that brings the Iconify catalog into the ad
 
 ## Demo
 
-[Open the demo video directly](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/IconHubPluginDemo.mp4)
+[Open the demo video directly](https://res.cloudinary.com/dcmxgdy82/video/upload/v1776598257/github/strapi-plugin-iconhub/assets/docs/IconHubPluginDemo.mp4)
 
 The demo covers the picker flow, icon set browsing, icon editing, and color customization.
 
@@ -62,18 +62,18 @@ npm run develop
 
 Verify the plugin in **Settings > Plugins**.
 
-![Plugin verification](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/plugin-verification.png)
+![Plugin verification](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598288/github/strapi-plugin-iconhub/assets/docs/plugin-verification.png)
 
 ## Add the field to a content type
 
 Open **Content-Type Builder**, add a new custom field, and select **IconHub**.
 
-![Custom field tab](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/custom-field-tab.png)
-![IconHub custom field selection](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/iconhub-custom-field-selection.png)
+![Custom field tab](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598261/github/strapi-plugin-iconhub/assets/docs/custom-field-tab.png)
+![IconHub custom field selection](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598287/github/strapi-plugin-iconhub/assets/docs/iconhub-custom-field-selection.png)
 
 The field then appears in the content entry UI like any other Strapi input.
 
-![Empty IconHub field input](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-custom-field-input.png)
+![Empty IconHub field input](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598265/github/strapi-plugin-iconhub/assets/docs/icon-custom-field-input.png)
 
 ## Field configuration
 
@@ -87,13 +87,13 @@ IconHub supports three storage modes:
 
 This is configured in the field settings.
 
-![Configure storage preferences](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/configure-storage-preferences.png)
+![Configure storage preferences](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598260/github/strapi-plugin-iconhub/assets/docs/configure-storage-preferences.png)
 
 ### Restrict available icon set categories
 
 In **Basic Settings**, you can decide which Iconify collection categories are available for this field. This is the main control for narrowing the picker to a design system, brand icon family, emoji-only field, and similar editorial use cases.
 
-![Configure available icon set categories](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/configure-available-icon-set-categories.png)
+![Configure available icon set categories](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598259/github/strapi-plugin-iconhub/assets/docs/configure-available-icon-set-categories.png)
 
 ## Editor workflow
 
@@ -101,9 +101,9 @@ In **Basic Settings**, you can decide which Iconify collection categories are av
 
 The default picker state is built around icon-set discovery. Editors can browse allowed categories first, then open a set when they want a tighter visual search space.
 
-![Picker default state example 1](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example.png)
-![Picker default state example 2](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-2.png)
-![Picker default state example 3](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-3.png)
+![Picker default state example 1](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598272/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example.png)
+![Picker default state example 2](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598268/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-2.png)
+![Picker default state example 3](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598271/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-3.png)
 
 ### 2. Refine the available sets
 
@@ -113,15 +113,15 @@ The discovery view supports metadata-driven filtering for common browsing patter
 - grid / icon height filtering
 - palette and license filtering
 
-![Filter icon sets by tag](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-tag-example.png)
-![Filter icon sets by grid](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-grid-example.png)
-![Filter icon sets by palette and license](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-palette-and-license-example.png)
+![Filter icon sets by tag](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598277/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-tag-example.png)
+![Filter icon sets by grid](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598274/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-grid-example.png)
+![Filter icon sets by palette and license](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598275/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-palette-and-license-example.png)
 
 ### 3. Search globally or open a specific set
 
 Editors can search across all allowed sets from the main toolbar, or open a single set for focused browsing and in-set search.
 
-![Google Material Icons set view](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-google-material-icons-icon-set-example-state-for-showing-search-inside-iconset.png)
+![Google Material Icons set view](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598278/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-google-material-icons-icon-set-example-state-for-showing-search-inside-iconset.png)
 
 The set browser keeps the current set context visible:
 
@@ -135,17 +135,17 @@ The set browser keeps the current set context visible:
 
 The picker works well across both monotone and multicolor sets.
 
-![Material Design icons example](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-icons-demo-material-design-icons-iconset-example.png)
-![Fluent UI System Color icons example](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-icons-demo-fluent-ui-system-color-icons-iconset-example.png)
-![Emoji One icons example](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-icons-demo-emoji-one-icons-iconset-example.png)
-![Stickies color icons example](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-modal-icons-demo-stickies-color-icons-iconset-example.png)
+![Material Design icons example](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598284/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-material-design-icons-iconset-example.png)
+![Fluent UI System Color icons example](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598282/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-fluent-ui-system-color-icons-iconset-example.png)
+![Emoji One icons example](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598280/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-emoji-one-icons-iconset-example.png)
+![Stickies color icons example](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598286/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-stickies-color-icons-iconset-example.png)
 
 ### 5. Edit and customize the selected icon
 
 Once an icon is selected, the field shows the chosen icon in the entry form and exposes an edit action for further adjustments.
 
-![Field input with selected icon and color](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-custom-field-input-with-selected-icon-and-color.png)
-![Edit button on field input](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-custom-field-input-edit-button.png)
+![Field input with selected icon and color](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598264/github/strapi-plugin-iconhub/assets/docs/icon-custom-field-input-with-selected-icon-and-color.png)
+![Edit button on field input](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598262/github/strapi-plugin-iconhub/assets/docs/icon-custom-field-input-edit-button.png)
 
 The edit modal includes:
 
@@ -155,8 +155,8 @@ The edit modal includes:
 - icon name and raw SVG editing controls
 - download actions for exported assets
 
-![Icon edit modal](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-edit-modal.png)
-![Visual color picker](https://cdn.jsdelivr.net/gh/Arshiash80/strapi-plugin-iconhub@main/assets/docs/icon-picker-edit-modal-color-picker.png)
+![Icon edit modal](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598267/github/strapi-plugin-iconhub/assets/docs/icon-picker-edit-modal.png)
+![Visual color picker](https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598266/github/strapi-plugin-iconhub/assets/docs/icon-picker-edit-modal-color-picker.png)
 
 ## Stored value shape
 
@@ -240,6 +240,7 @@ npm run build
 npm run watch
 npm run watch:link
 npm run verify
+npm run docs:sync-media
 npm run docs:readme
 ```
 
@@ -252,13 +253,14 @@ npx tsc -p server/tsconfig.json --noEmit
 
 ## Documentation assets
 
-Documentation images are stored in `assets/docs/`. Update `README.source.md`, then regenerate the published README:
+Documentation images and videos are stored in `assets/docs/`. Update `README.source.md`, sync changed assets to Cloudinary, then regenerate the published README:
 
 ```bash
+npm run docs:sync-media
 npm run docs:readme
 ```
 
-The generated `README.md` rewrites local screenshot paths to jsDelivr URLs so the images render correctly on GitHub, npm, and the Strapi marketplace.
+The Cloudinary sync script uploads only changed README assets, stores their content hashes in `docs/readme-media-manifest.json`, and lets `README.md` use Cloudinary delivery URLs for marketplace-safe media rendering. Unsynced assets fall back to jsDelivr URLs.
 
 ## License
 

--- a/README.source.md
+++ b/README.source.md
@@ -238,6 +238,7 @@ npm run build
 npm run watch
 npm run watch:link
 npm run verify
+npm run docs:sync-media
 npm run docs:readme
 ```
 
@@ -250,13 +251,14 @@ npx tsc -p server/tsconfig.json --noEmit
 
 ## Documentation assets
 
-Documentation images are stored in `assets/docs/`. Update `README.source.md`, then regenerate the published README:
+Documentation images and videos are stored in `assets/docs/`. Update `README.source.md`, sync changed assets to Cloudinary, then regenerate the published README:
 
 ```bash
+npm run docs:sync-media
 npm run docs:readme
 ```
 
-The generated `README.md` rewrites local screenshot paths to jsDelivr URLs so the images render correctly on GitHub, npm, and the Strapi marketplace.
+The Cloudinary sync script uploads only changed README assets, stores their content hashes in `docs/readme-media-manifest.json`, and lets `README.md` use Cloudinary delivery URLs for marketplace-safe media rendering. Unsynced assets fall back to jsDelivr URLs.
 
 ## License
 

--- a/docs/readme-media-manifest.json
+++ b/docs/readme-media-manifest.json
@@ -1,0 +1,214 @@
+{
+  "provider": "cloudinary",
+  "generatedAt": "2026-04-19T11:33:50.163Z",
+  "uploadRoot": "github/strapi-plugin-iconhub",
+  "assets": {
+    "assets/docs/IconHubPluginDemo.mp4": {
+      "bytes": 7289112,
+      "format": "mp4",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/IconHubPluginDemo",
+      "resourceType": "video",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/video/upload/v1776598257/github/strapi-plugin-iconhub/assets/docs/IconHubPluginDemo.mp4",
+      "version": 1776598257,
+      "sha256": "5c52781208b7048e488d92378d4851732a1b9c9e2b90b3782f28fb4489801f28"
+    },
+    "assets/docs/configure-available-icon-set-categories.png": {
+      "bytes": 243550,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/configure-available-icon-set-categories",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598259/github/strapi-plugin-iconhub/assets/docs/configure-available-icon-set-categories.png",
+      "version": 1776598259,
+      "sha256": "9f6d529194132d800ff56fe04d41931ecb275db4a7b582f664bca4241d150e18"
+    },
+    "assets/docs/configure-storage-preferences.png": {
+      "bytes": 139494,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/configure-storage-preferences",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598260/github/strapi-plugin-iconhub/assets/docs/configure-storage-preferences.png",
+      "version": 1776598260,
+      "sha256": "bee88002e3efda06425ec1dc8e50fb92e1da8c79a4fa6b8b712ac52a1620643d"
+    },
+    "assets/docs/custom-field-tab.png": {
+      "bytes": 439314,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/custom-field-tab",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598261/github/strapi-plugin-iconhub/assets/docs/custom-field-tab.png",
+      "version": 1776598261,
+      "sha256": "6bfe717aa6589ee2e3741bf223f0687306f2a40ac2cce3e3d1c424931ee3387a"
+    },
+    "assets/docs/icon-custom-field-input-edit-button.png": {
+      "bytes": 141623,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-custom-field-input-edit-button",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598262/github/strapi-plugin-iconhub/assets/docs/icon-custom-field-input-edit-button.png",
+      "version": 1776598262,
+      "sha256": "a90697a3f7f6d7c67c35ba9dfe3aaa44dfda777077e19829b5de38ae16343104"
+    },
+    "assets/docs/icon-custom-field-input-with-selected-icon-and-color.png": {
+      "bytes": 87126,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-custom-field-input-with-selected-icon-and-color",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598264/github/strapi-plugin-iconhub/assets/docs/icon-custom-field-input-with-selected-icon-and-color.png",
+      "version": 1776598264,
+      "sha256": "e0567c0bc43f6857b1a664271bcdd92acb16f764b7ad685e2556abcb1e92670f"
+    },
+    "assets/docs/icon-custom-field-input.png": {
+      "bytes": 135592,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-custom-field-input",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598265/github/strapi-plugin-iconhub/assets/docs/icon-custom-field-input.png",
+      "version": 1776598265,
+      "sha256": "5a605c609756a11f89b9724a953d711958480c0ccb89f56c0d3ce6289c642e62"
+    },
+    "assets/docs/icon-picker-edit-modal-color-picker.png": {
+      "bytes": 317386,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-edit-modal-color-picker",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598266/github/strapi-plugin-iconhub/assets/docs/icon-picker-edit-modal-color-picker.png",
+      "version": 1776598266,
+      "sha256": "15e022a09dd3fd8ac19a94588ceb317d2f405320117c67b4e30c211fade42e30"
+    },
+    "assets/docs/icon-picker-edit-modal.png": {
+      "bytes": 210042,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-edit-modal",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598267/github/strapi-plugin-iconhub/assets/docs/icon-picker-edit-modal.png",
+      "version": 1776598267,
+      "sha256": "87c477c6313f0b1d4bc4569694c39020b702d2748dc2da836214a6dcdd767e60"
+    },
+    "assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-2.png": {
+      "bytes": 406321,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-2",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598268/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-2.png",
+      "version": 1776598268,
+      "sha256": "a0d1f80b3cdd90dec54c946fa2496d92e5d0186489a4b8d8bbe1945e072fe9f6"
+    },
+    "assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-3.png": {
+      "bytes": 454952,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-3",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598271/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example-3.png",
+      "version": 1776598271,
+      "sha256": "d23f2be34bc8083fc88f849369a90eb59c7eee70ea021f70c2f383f3f5b84893"
+    },
+    "assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example.png": {
+      "bytes": 426126,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598272/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example.png",
+      "version": 1776598272,
+      "sha256": "4d19d46e77b8edb3c7fdbee0815f4964b8a3ef9e8bfd2eb83f94b020db5c2c36"
+    },
+    "assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-grid-example.png": {
+      "bytes": 515385,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-grid-example",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598274/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-grid-example.png",
+      "version": 1776598274,
+      "sha256": "b8fc25a5189f185a8e7721d72601f4878711bae1c32f6cdf45e19470c5fdcc26"
+    },
+    "assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-palette-and-license-example.png": {
+      "bytes": 542420,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-palette-and-license-example",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598275/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-palette-and-license-example.png",
+      "version": 1776598275,
+      "sha256": "931a1d1cc516c3f78f78dd268a592ce24143c883f3cf83df1ccd13e7cd356574"
+    },
+    "assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-tag-example.png": {
+      "bytes": 493067,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-tag-example",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598277/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-filter-by-tag-example.png",
+      "version": 1776598277,
+      "sha256": "91580b2a75c97d085c91e040272e9c31a9ac00eaee6d0e708f7401092bff4b43"
+    },
+    "assets/docs/icon-picker-modal-google-material-icons-icon-set-example-state-for-showing-search-inside-iconset.png": {
+      "bytes": 398271,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-google-material-icons-icon-set-example-state-for-showing-search-inside-iconset",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598278/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-google-material-icons-icon-set-example-state-for-showing-search-inside-iconset.png",
+      "version": 1776598278,
+      "sha256": "64b148ee7515ce6d166bdcfeb650b13eb346fffa4844c7de3c0fd67a5fe6a499"
+    },
+    "assets/docs/icon-picker-modal-icons-demo-emoji-one-icons-iconset-example.png": {
+      "bytes": 508561,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-emoji-one-icons-iconset-example",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598280/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-emoji-one-icons-iconset-example.png",
+      "version": 1776598280,
+      "sha256": "87cecc06f8a08a5f0b8d80ca3faace1de4754966843105cbc491090b543adab5"
+    },
+    "assets/docs/icon-picker-modal-icons-demo-fluent-ui-system-color-icons-iconset-example.png": {
+      "bytes": 530010,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-fluent-ui-system-color-icons-iconset-example",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598282/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-fluent-ui-system-color-icons-iconset-example.png",
+      "version": 1776598282,
+      "sha256": "f6fb8a87341f8daca7ebfc02f97bfe09d7a100b5be694dcb598666699640c7d6"
+    },
+    "assets/docs/icon-picker-modal-icons-demo-material-design-icons-iconset-example.png": {
+      "bytes": 631655,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-material-design-icons-iconset-example",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598284/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-material-design-icons-iconset-example.png",
+      "version": 1776598284,
+      "sha256": "b8baf3d861b791ed7b2a36b07d5a48225f896c846c76f6c255a65168680d5418"
+    },
+    "assets/docs/icon-picker-modal-icons-demo-stickies-color-icons-iconset-example.png": {
+      "bytes": 631655,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-stickies-color-icons-iconset-example",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598286/github/strapi-plugin-iconhub/assets/docs/icon-picker-modal-icons-demo-stickies-color-icons-iconset-example.png",
+      "version": 1776598286,
+      "sha256": "b8baf3d861b791ed7b2a36b07d5a48225f896c846c76f6c255a65168680d5418"
+    },
+    "assets/docs/iconhub-custom-field-selection.png": {
+      "bytes": 295386,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/iconhub-custom-field-selection",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598287/github/strapi-plugin-iconhub/assets/docs/iconhub-custom-field-selection.png",
+      "version": 1776598287,
+      "sha256": "be184410b5a68be96346e6995807eca33a0ca43b7f0952ab4ee1fb96c30dfc26"
+    },
+    "assets/docs/og-image.jpg": {
+      "bytes": 68030,
+      "format": "jpg",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/og-image",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598287/github/strapi-plugin-iconhub/assets/docs/og-image.jpg",
+      "version": 1776598287,
+      "sha256": "f8a143b929163d66833df4ebbfc9f1f47e4983c698604eb8e35026a98fce563a"
+    },
+    "assets/docs/plugin-verification.png": {
+      "bytes": 289813,
+      "format": "png",
+      "publicId": "github/strapi-plugin-iconhub/assets/docs/plugin-verification",
+      "resourceType": "image",
+      "secureUrl": "https://res.cloudinary.com/dcmxgdy82/image/upload/v1776598288/github/strapi-plugin-iconhub/assets/docs/plugin-verification.png",
+      "version": 1776598288,
+      "sha256": "6beb3b3ea7ed48ba8055c219f93027f8fadfa243ac0213718c5be2938d3b058d"
+    }
+  }
+}

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,6 +1,6 @@
-# Documentation Screenshot Workflow
+# Documentation Media Workflow
 
-The published README uses images stored in `assets/docs/`. Keep those files stable and overwrite existing assets when the UI changes, instead of creating dated one-off screenshots.
+The published README uses media stored in `assets/docs/`. Keep those files stable and overwrite existing assets when the UI changes, instead of creating dated one-off screenshots. The README generator prefers Cloudinary URLs from `docs/readme-media-manifest.json` and falls back to jsDelivr only when an asset has not been synced yet.
 
 ## Current asset groups
 
@@ -23,6 +23,8 @@ The published README uses images stored in `assets/docs/`. Keep those files stab
   - `icon-picker-modal-icons-demo-*.png`
 - marketing / cover image
   - `og-image.jpg`
+- demo media
+  - `IconHubPluginDemo.mp4`
 
 ## Capture rules
 
@@ -41,15 +43,26 @@ The published README uses images stored in `assets/docs/`. Keep those files stab
 ![Picker default state](assets/docs/icon-picker-modal-default-state-with-icons-sets-and-no-search-example.png)
 ```
 
-3. Regenerate the published README
+3. Sync changed README assets to Cloudinary
+
+```bash
+export CLOUDINARY_CLOUD_NAME=your-cloud-name
+export CLOUDINARY_API_KEY=your-api-key
+export CLOUDINARY_API_SECRET=your-api-secret
+npm run docs:sync-media
+```
+
+Only changed assets are uploaded. The script computes a SHA-256 hash for each README asset, stores the result in `docs/readme-media-manifest.json`, and skips assets whose content hash is unchanged.
+
+4. Regenerate the published README
 
 ```bash
 npm run docs:readme
 ```
 
-The generator rewrites local image paths to jsDelivr URLs so the same README renders correctly on GitHub, npm, and the Strapi marketplace.
+The generator rewrites local media paths to Cloudinary URLs when they exist in the manifest. If an asset has not been synced yet, it falls back to jsDelivr so GitHub previews still work.
 
-For pull request previews, generate against the current commit SHA so newly added screenshots render before merge:
+For pull request previews, generate against the current commit SHA so newly added fallback assets render before merge:
 
 ```bash
 README_CDN_REF=$(git rev-parse HEAD) npm run docs:readme
@@ -57,7 +70,7 @@ README_CDN_REF=$(git rev-parse HEAD) npm run docs:readme
 
 ## Optional release flow
 
-To pin image URLs to a release instead of `main`:
+If you intentionally want fallback jsDelivr URLs pinned to a release instead of `main`:
 
 ```bash
 README_CDN_REF=v1.2.0 npm run docs:readme

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "watch": "strapi-plugin watch",
     "watch:link": "strapi-plugin watch:link",
     "verify": "strapi-plugin verify",
+    "docs:sync-media": "node scripts/sync-readme-assets-to-cloudinary.mjs",
     "docs:readme": "node scripts/generate-readme.mjs",
     "test:ts:front": "run -T tsc -p admin/tsconfig.json",
     "test:ts:back": "run -T tsc -p server/tsconfig.json"

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -5,6 +5,7 @@ const repoRoot = process.cwd();
 const sourcePath = path.join(repoRoot, 'README.source.md');
 const outputPath = path.join(repoRoot, 'README.md');
 const packageJsonPath = path.join(repoRoot, 'package.json');
+const cloudinaryManifestPath = path.join(repoRoot, 'docs', 'readme-media-manifest.json');
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 const repositoryUrl = packageJson.repository?.url ?? '';
@@ -17,6 +18,19 @@ if (!repositoryMatch) {
 const repositorySlug = repositoryMatch[1];
 const cdnRef = process.env.README_CDN_REF || 'main';
 const cdnBaseUrl = `https://cdn.jsdelivr.net/gh/${repositorySlug}@${cdnRef}/`;
+const cloudinaryManifest = fs.existsSync(cloudinaryManifestPath)
+  ? JSON.parse(fs.readFileSync(cloudinaryManifestPath, 'utf8'))
+  : { assets: {} };
+
+const resolveAssetUrl = (filePath) => {
+  const cloudinaryUrl = cloudinaryManifest.assets?.[filePath]?.secureUrl;
+
+  if (cloudinaryUrl) {
+    return cloudinaryUrl;
+  }
+
+  return `${cdnBaseUrl}${encodeRepoPath(filePath)}`;
+};
 
 const encodeRepoPath = (filePath) =>
   filePath
@@ -25,27 +39,27 @@ const encodeRepoPath = (filePath) =>
     .join('/');
 
 const rewriteMarkdownImage = (_, altText, imagePath) => {
-  const absoluteUrl = `${cdnBaseUrl}${encodeRepoPath(imagePath)}`;
+  const absoluteUrl = resolveAssetUrl(imagePath);
   return `![${altText}](${absoluteUrl})`;
 };
 
 const rewriteMarkdownAssetLink = (_, linkText, assetPath) => {
-  const absoluteUrl = `${cdnBaseUrl}${encodeRepoPath(assetPath)}`;
+  const absoluteUrl = resolveAssetUrl(assetPath);
   return `[${linkText}](${absoluteUrl})`;
 };
 
 const rewriteMarkdownLinkedImage = (_, imageMarkdown, assetPath) => {
-  const absoluteUrl = `${cdnBaseUrl}${encodeRepoPath(assetPath)}`;
+  const absoluteUrl = resolveAssetUrl(assetPath);
   return `[${imageMarkdown}](${absoluteUrl})`;
 };
 
 const rewriteMarkdownMediaLink = (_, assetPath) => {
-  const absoluteUrl = `${cdnBaseUrl}${encodeRepoPath(assetPath)}`;
+  const absoluteUrl = resolveAssetUrl(assetPath);
   return `](${absoluteUrl})`;
 };
 
 const rewriteHtmlAssetSrc = (_, prefix, assetPath, suffix) => {
-  const absoluteUrl = `${cdnBaseUrl}${encodeRepoPath(assetPath)}`;
+  const absoluteUrl = resolveAssetUrl(assetPath);
   return `${prefix}${absoluteUrl}${suffix}`;
 };
 

--- a/scripts/sync-readme-assets-to-cloudinary.mjs
+++ b/scripts/sync-readme-assets-to-cloudinary.mjs
@@ -1,0 +1,211 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const sourcePath = path.join(repoRoot, 'README.source.md');
+const manifestPath = path.join(repoRoot, 'docs', 'readme-media-manifest.json');
+
+const loadEnvFile = (filePath) => {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf('=');
+
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    let value = line.slice(separatorIndex + 1).trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+};
+
+loadEnvFile(path.join(repoRoot, '.env.local'));
+loadEnvFile(path.join(repoRoot, '.env'));
+
+const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
+const apiKey = process.env.CLOUDINARY_API_KEY;
+const apiSecret = process.env.CLOUDINARY_API_SECRET;
+const uploadRoot = process.env.CLOUDINARY_README_FOLDER || 'strapi-plugin-iconhub/readme';
+
+const requiredEnv = ['CLOUDINARY_CLOUD_NAME', 'CLOUDINARY_API_KEY', 'CLOUDINARY_API_SECRET'].filter(
+  (key) => !process.env[key]
+);
+
+if (requiredEnv.length > 0) {
+  throw new Error(`Missing Cloudinary environment variables: ${requiredEnv.join(', ')}`);
+}
+
+const readmeSource = fs.readFileSync(sourcePath, 'utf8');
+
+const collectAssetPaths = (content) => {
+  const patterns = [
+    /\[(!\[[^\]]*\]\([^)]+\))\]\(((?:assets\/docs|docs\/screenshots)\/[^)]+)\)/g,
+    /!\[[^\]]*\]\(((?:assets\/docs|docs\/screenshots)\/[^)]+)\)/g,
+    /\[[^\]]+\]\(((?:assets\/docs|docs\/screenshots)\/[^)]+)\)/g,
+    /(?:src|poster)="((?:assets\/docs|docs\/screenshots)\/[^"]+)"/g,
+  ];
+
+  const assets = new Set();
+
+  patterns.forEach((pattern) => {
+    for (const match of content.matchAll(pattern)) {
+      const candidate = match.at(-1);
+
+      if (candidate) {
+        assets.add(candidate);
+      }
+    }
+  });
+
+  return [...assets].sort();
+};
+
+const getResourceType = (relativePath) => {
+  const extension = path.extname(relativePath).toLowerCase();
+
+  if (['.mp4', '.mov', '.webm', '.m4v'].includes(extension)) {
+    return 'video';
+  }
+
+  if (['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.avif'].includes(extension)) {
+    return 'image';
+  }
+
+  return 'raw';
+};
+
+const computeSha256 = (buffer) => crypto.createHash('sha256').update(buffer).digest('hex');
+
+const buildPublicId = (relativePath) => {
+  const normalized = relativePath.replace(/\\/g, '/');
+  const withoutExtension = normalized.replace(path.extname(normalized), '');
+  return `${uploadRoot}/${withoutExtension}`;
+};
+
+const readManifest = () => {
+  if (!fs.existsSync(manifestPath)) {
+    return { provider: 'cloudinary', assets: {} };
+  }
+
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+};
+
+const writeManifest = (manifest) => {
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+};
+
+const signParams = (params) => {
+  const toSign = Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+
+  return crypto.createHash('sha1').update(`${toSign}${apiSecret}`).digest('hex');
+};
+
+const uploadAsset = async (absolutePath, relativePath) => {
+  const resourceType = getResourceType(relativePath);
+  const publicId = buildPublicId(relativePath);
+  const timestamp = Math.floor(Date.now() / 1000);
+
+  const params = {
+    invalidate: 'true',
+    overwrite: 'true',
+    public_id: publicId,
+    timestamp: String(timestamp),
+  };
+
+  const signature = signParams(params);
+  const endpoint = `https://api.cloudinary.com/v1_1/${cloudName}/${resourceType}/upload`;
+  const fileBuffer = fs.readFileSync(absolutePath);
+  const form = new FormData();
+
+  form.set('file', new Blob([fileBuffer]), path.basename(absolutePath));
+  form.set('api_key', apiKey);
+  form.set('timestamp', params.timestamp);
+  form.set('public_id', params.public_id);
+  form.set('overwrite', params.overwrite);
+  form.set('invalidate', params.invalidate);
+  form.set('signature', signature);
+
+  const response = await fetch(endpoint, { method: 'POST', body: form });
+  const body = await response.json();
+
+  if (!response.ok) {
+    throw new Error(`Cloudinary upload failed for ${relativePath}: ${JSON.stringify(body)}`);
+  }
+
+  return {
+    bytes: body.bytes,
+    format: body.format,
+    publicId: body.public_id,
+    resourceType: body.resource_type,
+    secureUrl: body.secure_url,
+    version: body.version,
+  };
+};
+
+const assetPaths = collectAssetPaths(readmeSource);
+const manifest = readManifest();
+const nextAssets = {};
+
+for (const relativePath of assetPaths) {
+  const absolutePath = path.join(repoRoot, relativePath);
+
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`README asset not found: ${relativePath}`);
+  }
+
+  const fileBuffer = fs.readFileSync(absolutePath);
+  const sha256 = computeSha256(fileBuffer);
+  const existing = manifest.assets?.[relativePath];
+
+  if (existing?.sha256 === sha256 && existing?.secureUrl) {
+    nextAssets[relativePath] = existing;
+    console.log(`skip  ${relativePath}`);
+    continue;
+  }
+
+  console.log(`upload ${relativePath}`);
+  const uploaded = await uploadAsset(absolutePath, relativePath);
+
+  nextAssets[relativePath] = {
+    ...uploaded,
+    sha256,
+  };
+}
+
+const nextManifest = {
+  provider: 'cloudinary',
+  generatedAt: new Date().toISOString(),
+  uploadRoot,
+  assets: nextAssets,
+};
+
+writeManifest(nextManifest);
+
+console.log(`Synced ${Object.keys(nextAssets).length} README asset(s) to Cloudinary.`);


### PR DESCRIPTION
## Summary

This updates the README media workflow so documentation assets can use stable external URLs instead of relying entirely on repo-relative delivery.

## What changed

- added a Cloudinary sync script for README images and video
- added a manifest that stores uploaded asset URLs and content hashes
- updated README generation to prefer Cloudinary URLs and fall back to jsDelivr when needed
- documented the maintainer workflow for syncing media and regenerating the README

## Why

Strapi Marketplace and other package surfaces are more reliable with stable absolute media URLs. This keeps the README source in the repo while avoiding unnecessary re-uploads of unchanged assets.

Closes #14